### PR TITLE
Release v1.0.48

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -48,12 +48,7 @@
 
     ; clj -M:test or clj -X:test
     :test {:extra-paths ["test"]
-           :extra-deps  {io.github.cognitect-labs/test-runner {:git/tag "v0.5.0" :git/sha "b3fd0d2"}
-                         ch.qos.logback/logback-classic       {:mvn/version "1.2.10"}
-                         org.slf4j/slf4j-api                  {:mvn/version "1.7.32"}
-                         org.slf4j/jcl-over-slf4j             {:mvn/version "1.7.32"}
-                         org.slf4j/log4j-over-slf4j           {:mvn/version "1.7.32"}
-                         org.slf4j/jul-to-slf4j               {:mvn/version "1.7.32"}}
+           :extra-deps  {io.github.cognitect-labs/test-runner {:git/tag "v0.5.0" :git/sha "b3fd0d2"}}
            :main-opts   ["-m" "cognitect.test-runner"]
            :exec-fn     cognitect.test-runner.api/test}
 
@@ -77,5 +72,5 @@
       {:extra-deps {codox/codox {:mvn/version "0.10.8"}}
        :exec-fn    codox.main/generate-docs
        :exec-args  {:source-paths ["src"]
-                    :source-uri   "https://github.com/pmonks/lice-comb/blob/main/{filepath}#L{line}"}}
+                    :source-uri   "https://github.com/pmonks/discljord-utils/blob/main/{filepath}#L{line}"}}
    }}


### PR DESCRIPTION
com.github.pmonks/discljord-utils release v1.0.48. See commit log for details of what's included in this release.